### PR TITLE
Add currently unused envvars for future impls

### DIFF
--- a/.github/workflows/git-gopher-test.yml
+++ b/.github/workflows/git-gopher-test.yml
@@ -41,6 +41,8 @@ jobs:
           ./bin/go-gopher-github-action
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       - name: Artifact outputs
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/git-gopher.yml
+++ b/.github/workflows/git-gopher.yml
@@ -28,6 +28,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_URL: ${{ github.server_url }}/${{ github.repository }}/
+          PR_NUMBER: ${{ github.event.number }}
+          WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
       - name: Add PR Comment
         uses: marocchino/sticky-pull-request-comment@v2
         with:


### PR DESCRIPTION
- Future work requires these envvars to be defined
- Distribution of the github action will probably happen this week. Not sure if current work will make it in before distribution
- Distribute envvars which can't be changed later after distribution which allows for future work to happen at anytime